### PR TITLE
Update the repository deletion and disable false warnings

### DIFF
--- a/harborclient/client.py
+++ b/harborclient/client.py
@@ -22,6 +22,8 @@ from harborclient import utils
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
 
 class HTTPClient(object):
     USER_AGENT = 'python-harborclient'

--- a/harborclient/v2/repositories.py
+++ b/harborclient/v2/repositories.py
@@ -2,6 +2,12 @@ from harborclient import base
 
 
 class RepositoryManager(base.Manager):
+    def is_name(self, key):
+        if key.isdigit():
+            return False
+        else:
+            return True
+
     def get(self, id):
         """Get a Repository."""
         return self._get("/repositories/%s" % id)
@@ -14,7 +20,7 @@ class RepositoryManager(base.Manager):
     def delete_repository(self, repo_name):
         """Delete the repository."""
         return self.api.client.delete(
-            "/repositories/%s" % repo_name)
+           "/repositories/%s" % repo_name)
 
     def list_tags(self, repo_name):
         """Get the tag of the repository."""
@@ -23,7 +29,7 @@ class RepositoryManager(base.Manager):
 
     def delete_tags(self, repo_name, tag_name):
         """Delete the tag of the repository."""
-        return self.api.client.delete(
+        return self._delete(
             "/repositories/%s/tags/%s" % (repo_name, tag_name))
 
     def get_manifests(self, repo_name, tag):

--- a/harborclient/v2/shell.py
+++ b/harborclient/v2/shell.py
@@ -356,15 +356,18 @@ def do_list(cs, args):
     help="will only print what would have been deleted")
 def do_repository_delete(cs, args):
     """Delete repository"""
-    # list all the repositories to delete
-    repositories = cs.repositories.list(cs.client.project)
-    for repo in repositories:
-        if re.match(args.repository, repo['name']):
-            if args.dryrun:
-                print("Would have deleted : %s" % repo['name'])
-            else:
-                cs.repositories.delete_repository(repo['name'])
-                print("Repository %s deleted" % repo['name'])
+    key = args.repository
+    if cs.repositories.is_name(key):
+        try:
+            cs.repositories.delete_repository(key)
+            print("Delete Repository '%s' successfully." % key)
+            return 0
+        except exp.NotFound:
+            print("Repository '%s' not Found." % args.repository)
+            return 1
+    else:
+        print("Repository name is needed.")
+        return 1
 
 
 @utils.arg('repository', metavar='<repository>', help='Name of repository.')


### PR DESCRIPTION
1) Add of a non-digit check for the key in _v2/repositories.py_
2) Update of the _do_repository_delete_ in the _v2/shell.py_ because the previous function did not work.
**Note** : the _do_tags_delete_ does not work too (the deletion of one tag, delete all the tags) because of an issue with the listing functions I think, but for the moment I could not investigate more to fix it...
3) **Workaround** : add an import library to disable the list of false SSL certificate warnings using Python 2.7