### PR TITLE
Enable us to use list command when using Python 3

### DIFF
--- a/harborclient/client.py
+++ b/harborclient/client.py
@@ -5,7 +5,7 @@ Harbor Client interface. Handles the REST calls and responses.
 import copy
 import hashlib
 import logging
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from oslo_utils import importutils
 import requests


### PR DESCRIPTION
When I use python-harborclient's `list` command with Python3, I met `ModuleNotFoundError` and this PR will fix it

```console
$ python -V
Python 3.7.0

$ cat ~/admin-harborrc
export HARBOR_USERNAME=sample
export HARBOR_PASSWORD=sample
export HARBOR_URL=https://reg.mydomain.com
export HARBOR_PROJECT=1

$ source ~/admin-harborrc
$ harbor list
Traceback (most recent call last):
  File "/Users/taku/.virtualenvs/py-harborclient/bin/harbor", line 6, in <module>
    from harborclient.shell import main
  File "/Users/taku/dev/src/github.com/takuan-osho/python-harborclient/harborclient/shell.py", line 17, in <module>
    from harborclient import client
  File "/Users/taku/dev/src/github.com/takuan-osho/python-harborclient/harborclient/client.py", line 8, in <module>
    from urlparse import urlparse
ModuleNotFoundError: No module named 'urlparse'
```